### PR TITLE
Fixed contributors icon list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ TML is largely created and maintained by a core team of contributors: **Blushiem
 This project exists in its current state thanks to all the people who have contributed:
 
 <a href="https://github.com/tModLoader/tModLoader/graphs/contributors">
-<img src="https://opencollective.com/tModLoader/contributors.svg?height=215&width=890&button=false" />
+<img src="https://opencollective.com/tModLoader/contributors.svg?width=890&button=false" />
 </a>
 
 ## License


### PR DESCRIPTION
## What is the bug?
The icon list under the "Contributors" tab got cut off after 215px.

#### Example:
> ![image](https://user-images.githubusercontent.com/26361108/154487100-df90bbed-9114-4655-9112-0fe2371fc8ac.png)

## How did you fix the bug?
Removed the "height" parameter from the URL, so the icon list doesn't cut off and rather changes height automatically when more people contribute.
